### PR TITLE
Fix state.init null check in exportReferencesGraph

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -748,7 +748,9 @@ in
             config.system.build.usr
             config.system.build.etc
           ]
-          ++ optionals config.state.enable [ config.state.init ];
+          ++ optionals (config.state.enable && config.state.init != null) [
+            config.state.init
+          ];
 
           env.manifest = builtins.toJSON {
             inherit (builtins) storeDir;


### PR DESCRIPTION
The `state.init` option is typed as `nullOr path` with a default of `null`, allowing users to enable state persistence without necessarily providing an init program. However, when `state.enable` is true, `state.init` was unconditionally added to `exportReferencesGraph.closure`, which means a null value could end up in the closure graph and cause the build to fail with:

```
error:
       … while parsing derivation '/nix/store/y3s...-mixos-initrd.drv'

       error: 'exportReferencesGraph' value is not an array or a string
```

This adds a null check so that `state.init` is only included in the closure when it is actually set to a path. The Zig side already handles a null state.init correctly — it simply skips running an init program and proceeds to mount the state directly. Tested locally and confirmed the build succeeds with the fix applied.