### PR TITLE
Handle PathAlreadyExists for /var/run symlink

### DIFF
--- a/src/init.zig
+++ b/src/init.zig
@@ -579,8 +579,9 @@ inline fn setupState(io: std.Io, root_dir: std.Io.Dir, lower_etc: []const u8) !v
         // Symlink /var/run to /run, which is a common symlink that is expected to
         // exist by many tools. We cannot do this at build time since var is tied
         // to /state, which is mounted at runtime.
-        dir.symLink(io, "../run", "run", .{ .is_directory = true }) catch |err| {
-            log.err("failed to symlink /var/run to /run: {}", .{err});
+        dir.symLink(io, "../run", "run", .{ .is_directory = true }) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => log.err("failed to symlink /var/run to /run: {}", .{err}),
         };
 
         // Ensure basic state directories exist


### PR DESCRIPTION
When `state.enable = true`, `/var` is mounted from `/state/var` at runtime. On the first boot, the `/var/run` -> `/run` symlink is created successfully. On subsequent boots, the symlink already exists on the persistent volume, causing the creation to fail with:

```
mixos: failed to symlink /var/run to /run: error.PathAlreadyExists
```
This fix handles `error.PathAlreadyExists` by silently ignoring it, matching the existing pattern used for the `/etc/mtab` -> `/proc/self/mounts` symlink. Other unexpected errors are still logged normally.