### PR TITLE
Create /var/lib during state setup

### DIFF
--- a/src/init.zig
+++ b/src/init.zig
@@ -585,6 +585,10 @@ inline fn setupState(io: std.Io, root_dir: std.Io.Dir, lower_etc: []const u8) !v
 
         // Ensure basic state directories exist
         {
+            dir.createDirPath(io, "lib") catch |err| {
+                log.err("failed to create /var/lib: {}", .{err});
+            };
+
             dir.createDirPath(io, "log") catch |err| {
                 log.err("failed to create /var/log: {}", .{err});
             };

--- a/src/init.zig
+++ b/src/init.zig
@@ -585,8 +585,8 @@ inline fn setupState(io: std.Io, root_dir: std.Io.Dir, lower_etc: []const u8) !v
 
         // Ensure basic state directories exist
         {
-            dir.createDirPath(io, "lib") catch |err| {
-                log.err("failed to create /var/lib: {}", .{err});
+            dir.createDirPath(io, "lib/misc") catch |err| {
+                log.err("failed to create /var/lib/misc: {}", .{err});
             };
 
             dir.createDirPath(io, "log") catch |err| {


### PR DESCRIPTION
I ran into a program that expected `/var/lib` to exist and failed because it wasn't being created during init. `/var/lib` is a standard FHS directory and most Linux systems have it, and many services expect it to be present.

This adds it to the existing `makePath` calls in `setupState()`, alongside `/var/run`, `/var/log` and `/var/spool`. Note that `/var/lib/misc` is the only required subdirectory of `/var/lib` per the [FHS 3.0
  spec](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s08.html#requirements13), so using `makePath("lib/misc")` creates both `/var/lib` and `/var/lib/misc` in one call.

Totally understand if you'd prefer this not be auto-created by init and instead left for users to create manually. Just figured I'd open this since it's a pretty standard directory and some other `/var` subdirectories are already being created here. Happy to close if you'd rather keep init minimal.

