### PR TITLE
Fix etc.hosts.source having no value when NET is disabled

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -524,14 +524,6 @@ in
         {
           "inittab".source = pkgs.writeText "mixos-inittab" inittab;
           "mdev.conf".source = pkgs.writeText "mdev.conf" config.mdev.rules;
-          "hosts".source = mkIf (kernelPackage.config.isYes "NET") (
-            mkDefault (
-              pkgs.writeText "etc-hosts" ''
-                127.0.0.1 localhost
-                ::1 localhost
-              ''
-            )
-          );
           "os-release".source = osReleaseFormat.generate "os-release" config.mixos.osRelease;
           "passwd".source = pkgs.writeText "passwd" (
             concatLines (
@@ -563,6 +555,14 @@ in
             )
           );
         }
+        (mkIf (kernelPackage.config.isYes "NET") {
+          "hosts".source = mkDefault (
+            pkgs.writeText "etc-hosts" ''
+              127.0.0.1 localhost
+              ::1 localhost
+            ''
+          );
+        })
         (mapAttrs' (name: service: {
           name = "service/${name}/run";
           value.source = service.run;


### PR DESCRIPTION
When building a system whose kernel does not have `NET` enabled, evaluation fails with:

```
error: The option `etc.hosts.source' was accessed but has no value defined.
```

The issue is that `mkIf` was wrapping the *value* of `etc."hosts".source` rather than the entire attribute entry. This meant the `"hosts"` key always existed in `config.etc`, but when NET was disabled, its `source` option had no value. When `system.build.etc` iterated over all entries and destructured `{ source, mode }`, it hit the undefined value.

The fix moves the `mkIf (kernelPackage.config.isYes "NET")` to wrap the entire `"hosts"` attrset as a separate element in the `mkMerge` list, so the key doesn't exist at all when NET is disabled.
